### PR TITLE
Release/v2.32.4

### DIFF
--- a/src/hooks/useDiscoverProvider.ts
+++ b/src/hooks/useDiscoverProvider.ts
@@ -36,6 +36,7 @@ export default function useDiscoverProvider() {
         signature.s.toString(16, 64),
         `0${signature.recoveryParam.toString()}`,
       ].join('');
+      signature.recoveryParam = Number(signature.recoveryParam);
 
       // recover pubkey by signature
       let publicKey;


### PR DESCRIPTION
Identify and resolve the issue causing the error message "The recovery param is more than two bits" when attempting to log in to TomorrowDAO using Portkey Wallet. The issue has been identified to be related to the signature process. close #466